### PR TITLE
[HDR & WCG patch3] Get EDID Blob to be reused for Parsing

### DIFF
--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -169,7 +169,8 @@ class DrmDisplay : public PhysicalDisplay {
                                         uint32_t possible_crtcs);
   std::vector<uint8_t *> FindExtendedBlocksForTag(uint8_t *edid,
                                                   uint8_t block_tag);
-  void DrmConnectorGetDCIP3Support(const ScopedDrmObjectPropertyPtr &props);
+  void ParseCTAFromExtensionBlock(uint8_t *edid);
+  void DrmConnectorGetDCIP3Support(uint8_t *b, uint8_t length);
 
   void TraceFirstCommit();
 


### PR DESCRIPTION
Move the EDID blob extraction so that it can parsed
and checked for other features.

Change-Id: Ibad63cef9372877b4b9002444ba85ca1776a651e
Tests: Tested on Linux Environment.
Tracked-On: None
Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>