### PR TITLE
[HDR & WCG patch6] Add Interfaces to set hdr metadata & colorspace from app

### DIFF
--- a/public/colorspace.h
+++ b/public/colorspace.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef PUBLIC_COLORSPACE_H
+#define PUBLIC_COLORSPACE_H
+
+/** A CIE 1931 color space*/
+struct cie_xy {
+  double x;
+  double y;
+};
+
+struct color_primaries {
+  struct cie_xy r;
+  struct cie_xy g;
+  struct cie_xy b;
+  struct cie_xy white_point;
+};
+
+struct colorspace {
+  struct color_primaries primaries;
+  const char *name;
+  const char *whitepoint_name;
+};
+
+enum colorspace_enums {
+  CS_BT470M,
+  CS_BT470BG,
+  CS_SMPTE170M,
+  CS_SMPTE240M,
+  CS_BT709,
+  CS_BT2020,
+  CS_SRGB,
+  CS_ADOBERGB,
+  CS_DCI_P3,
+  CS_PROPHOTORGB,
+  CS_CIERGB,
+  CS_CIEXYZ,
+  CS_AP0,
+  CS_AP1,
+  CS_UNDEFINED
+};
+#endif

--- a/public/hdr_metadata_defs.h
+++ b/public/hdr_metadata_defs.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2018 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef PUBLIC_HDR_METADATA_DEFS_H
+#define PUBLIC_HDR_METADATA_DEFS_H
+
+#include <stdint.h>
+#include "colorspace.h"
+
+enum hdr_metadata_type {
+  HDR_METADATA_TYPE1,
+  HDR_METADATA_TYPE2,
+};
+
+enum hdr_metadata_eotf {
+  EOTF_TRADITIONAL_GAMMA_SDR,
+  EOTF_TRADITIONAL_GAMMA_HDR,
+  EOTF_ST2084,
+  EOTF_HLG,
+};
+
+struct hdr_metadata_dynamic {
+  uint8_t size;
+  uint8_t *metadata;
+};
+
+struct hdr_metadata_static {
+  struct color_primaries primaries;
+  double max_luminance;
+  double min_luminance;
+  uint32_t max_cll;
+  uint32_t max_fall;
+  uint8_t eotf;
+};
+
+struct hdr_metadata {
+  enum hdr_metadata_type metadata_type;
+  union {
+    struct hdr_metadata_static static_metadata;
+    struct hdr_metadata_dynamic dynamic_metadata;
+  } metadata;
+};
+
+#endif

--- a/public/hwclayer.h
+++ b/public/hwclayer.h
@@ -18,8 +18,10 @@
 #define PUBLIC_HWCLAYER_H_
 
 #include <hwcdefs.h>
-
 #include <platformdefines.h>
+#include "hdr_metadata_defs.h"
+
+#define STATIC_METADATA(x) hdr_mdata.metadata.static_metadata.x
 
 namespace hwcomposer {
 
@@ -69,6 +71,35 @@ struct HwcLayer {
 
   void SetDisplayFrame(const HwcRect<int>& display_frame, int translate_x_pos,
                        int translate_y_pos);
+
+  void SetColorSpace(int clrspace) {
+    colorspace = clrspace;
+  }
+
+  void SetHdrMetadata(double primary_r_x, double primary_r_y,
+                      double primary_g_x, double primary_g_y,
+                      double primary_b_x, double primary_b_y,
+                      double white_point_x, double white_point_y,
+                      double max_luminance, double min_luminance, int max_cll,
+                      int max_fall) {
+    STATIC_METADATA(primaries.r.x) = primary_r_x;
+    STATIC_METADATA(primaries.r.y) = primary_r_y;
+    STATIC_METADATA(primaries.g.x) = primary_g_x;
+    STATIC_METADATA(primaries.g.y) = primary_g_y;
+    STATIC_METADATA(primaries.b.x) = primary_b_x;
+    STATIC_METADATA(primaries.b.y) = primary_b_y;
+    STATIC_METADATA(primaries.white_point.x) = white_point_x;
+    STATIC_METADATA(primaries.white_point.y) = white_point_y;
+    STATIC_METADATA(max_luminance) = max_luminance;
+    STATIC_METADATA(min_luminance) = min_luminance;
+    STATIC_METADATA(max_cll) = max_cll;
+    STATIC_METADATA(max_fall) = max_fall;
+  }
+
+  void SetHdrEotf(int internal_eotf) {
+    hdr_mdata.metadata_type = HDR_METADATA_TYPE1;
+    STATIC_METADATA(eotf) = internal_eotf;
+  }
 
   uint32_t GetDataSpace() const {
     return dataspace_;
@@ -343,6 +374,9 @@ struct HwcLayer {
   bool is_cursor_layer_ = false;
   bool is_video_layer_ = false;
   uint32_t solid_color_ = 0xff;
+
+  struct hdr_metadata hdr_mdata;
+  int colorspace;
 
   HWCLayerCompositionType composition_type_ = Composition_Device;
 };

--- a/tests/apps/linux_hdr_image_test.cpp
+++ b/tests/apps/linux_hdr_image_test.cpp
@@ -42,6 +42,7 @@
 
 #include <nativebufferhandler.h>
 #include "commondrmutils.h"
+#include "hdr_metadata_defs.h"
 #include "platformcommondefines.h"
 
 #define NUM_BUFFERS 1
@@ -631,6 +632,11 @@ int main(int argc, char *argv[]) {
   buffer->dev->unmap_bo(buffer);
 
   copy_buffer_to_handle(&native_handle, buffer);
+
+  layer.SetColorSpace(CS_BT2020);
+  layer.SetHdrMetadata(6550, 2300, 8500, 39850, 35400, 14600, 15635, 16450,
+                       1000, 100, 4000, 100);
+  layer.SetHdrEotf(EOTF_ST2084);
 
   layer.SetAcquireFence(-1);
   std::vector<hwcomposer::HwcRect<int>> damage_region;


### PR DESCRIPTION
Define new interfaces to be used by linux hdr app to set metadata & colorspace

Change-Id: I406625f7e19b975f86d67b51295d385b6094cfc2
Tests: Tested on Linux Environment.
Tracked-On: None
Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>