### PR TITLE
[HDR & WCG patch11] Added the implementation of HWC 2.3 API getPerFrameMetadataKeys

### DIFF
--- a/common/core/logicaldisplay.cpp
+++ b/common/core/logicaldisplay.cpp
@@ -257,4 +257,9 @@ bool LogicalDisplay::GetHdrCapabilities(uint32_t *outNumTypes,
   return true;
 }
 
+bool LogicalDisplay::GetPerFrameMetadataKeys(uint32_t *outNumKeys,
+                                             int32_t *outKeys) {
+  return true;
+}
+
 }  // namespace hwcomposer

--- a/common/core/logicaldisplay.h
+++ b/common/core/logicaldisplay.h
@@ -115,6 +115,8 @@ class LogicalDisplay : public NativeDisplay {
                           float *outMaxLuminance, float *outMaxAverageLuminance,
                           float *outMinLuminance) override;
 
+  bool GetPerFrameMetadataKeys(uint32_t *outNumKeys, int32_t *outKeys) override;
+
   uint32_t GetXTranslation() override {
     return (((physical_display_->Width()) / total_divisions_) * index_);
   }

--- a/common/core/mosaicdisplay.cpp
+++ b/common/core/mosaicdisplay.cpp
@@ -640,6 +640,11 @@ bool MosaicDisplay::GetHdrCapabilities(uint32_t *outNumTypes, int32_t *outTypes,
   return true;
 }
 
+bool MosaicDisplay::GetPerFrameMetadataKeys(uint32_t *outNumKeys,
+                                            int32_t *outKeys) {
+  return true;
+}
+
 void MosaicDisplay::SetHDCPState(HWCContentProtection state,
                                  HWCContentType content_type) {
   uint32_t size = physical_displays_.size();

--- a/common/core/mosaicdisplay.h
+++ b/common/core/mosaicdisplay.h
@@ -110,6 +110,7 @@ class MosaicDisplay : public NativeDisplay {
   bool GetHdrCapabilities(uint32_t *outNumTypes, int32_t *outTypes,
                           float *outMaxLuminance, float *outMaxAverageLuminance,
                           float *outMinLuminance) override;
+  bool GetPerFrameMetadataKeys(uint32_t *outNumKeys, int32_t *outKeys) override;
 
   uint32_t GetXTranslation() override {
     return 0;

--- a/common/display/virtualdisplay.cpp
+++ b/common/display/virtualdisplay.cpp
@@ -520,6 +520,11 @@ bool VirtualDisplay::GetHdrCapabilities(uint32_t *outNumTypes,
   return true;
 }
 
+bool VirtualDisplay::GetPerFrameMetadataKeys(uint32_t *outNumKeys,
+                                             int32_t *outKeys) {
+  return true;
+}
+
 int VirtualDisplay::GetDisplayPipe() {
   return -1;
 }

--- a/common/display/virtualdisplay.h
+++ b/common/display/virtualdisplay.h
@@ -86,6 +86,7 @@ class VirtualDisplay : public NativeDisplay {
   bool GetHdrCapabilities(uint32_t *outNumTypes, int32_t *outTypes,
                           float *outMaxLuminance, float *outMaxAverageLuminance,
                           float *outMinLuminance) override;
+  bool GetPerFrameMetadataKeys(uint32_t *outNumKeys, int32_t *outKeys) override;
 
   int GetDisplayPipe() override;
 

--- a/common/display/virtualpanoramadisplay.cpp
+++ b/common/display/virtualpanoramadisplay.cpp
@@ -510,6 +510,11 @@ bool VirtualPanoramaDisplay::GetHdrCapabilities(uint32_t *outNumTypes,
   return true;
 }
 
+bool VirtualPanoramaDisplay::GetPerFrameMetadataKeys(uint32_t *outNumKeys,
+                                                     int32_t *outKeys) {
+  return true;
+}
+
 bool VirtualPanoramaDisplay::GetDisplayConfigs(uint32_t *num_configs,
                                                uint32_t *configs) {
   if (!num_configs)

--- a/common/display/virtualpanoramadisplay.h
+++ b/common/display/virtualpanoramadisplay.h
@@ -89,7 +89,7 @@ class VirtualPanoramaDisplay : public NativeDisplay {
   bool GetHdrCapabilities(uint32_t *outNumTypes, int32_t *outTypes,
                           float *outMaxLuminance, float *outMaxAverageLuminance,
                           float *outMinLuminance) override;
-
+  bool GetPerFrameMetadataKeys(uint32_t *outNumKeys, int32_t *outKeys) override;
   bool SetPowerMode(uint32_t power_mode) override;
 
 #ifdef HYPER_DMABUF_SHARING

--- a/os/android/iahwc2.cpp
+++ b/os/android/iahwc2.cpp
@@ -648,6 +648,22 @@ HWC2::Error IAHWC2::HwcDisplay::GetHdrCapabilities(uint32_t *num_types,
   }
 }
 
+HWC2::Error IAHWC2::HwcDisplay::GetPerFrameMetadataKeys(uint32_t *outNumKeys,
+                                                        int32_t *outKeys) {
+  supported(__func__);
+
+  if (NULL == outNumKeys || NULL == outKeys) {
+    return HWC2::Error::BadParameter;
+  }
+
+  *outNumKeys = 0;
+  if (display_->GetPerFrameMetadataKeys(outNumKeys, outKeys)) {
+    return HWC2::Error::None;
+  } else {
+    return HWC2::Error::Unsupported;
+  }
+}
+
 HWC2::Error IAHWC2::HwcDisplay::GetReleaseFences(uint32_t *num_elements,
                                                  hwc2_layer_t *layers,
                                                  int32_t *fences) {
@@ -1427,6 +1443,11 @@ hwc2_function_pointer_t IAHWC2::HookDevGetFunction(struct hwc2_device * /*dev*/,
           DisplayHook<decltype(&HwcDisplay::GetHdrCapabilities),
                       &HwcDisplay::GetHdrCapabilities, uint32_t *, int32_t *,
                       float *, float *, float *>);
+    case HWC2::FunctionDescriptor::GetPerFrameMetadataKeys:
+      return ToHook<HWC2_PFN_GET_PER_FRAME_METADATA_KEYS>(
+          DisplayHook<decltype(&HwcDisplay::GetPerFrameMetadataKeys),
+                      &HwcDisplay::GetPerFrameMetadataKeys, uint32_t *,
+                      int32_t *>);
     case HWC2::FunctionDescriptor::GetReleaseFences:
       return ToHook<HWC2_PFN_GET_RELEASE_FENCES>(
           DisplayHook<decltype(&HwcDisplay::GetReleaseFences),

--- a/os/android/iahwc2.h
+++ b/os/android/iahwc2.h
@@ -232,6 +232,7 @@ class IAHWC2 : public hwc2_device_t {
                                    float *max_luminance,
                                    float *max_average_luminance,
                                    float *min_luminance);
+    HWC2::Error GetPerFrameMetadataKeys(uint32_t *outNumKeys, int32_t *outKeys);
     HWC2::Error GetReleaseFences(uint32_t *num_elements, hwc2_layer_t *layers,
                                  int32_t *fences);
     HWC2::Error PresentDisplay(int32_t *retire_fence);

--- a/public/hdr_metadata_defs.h
+++ b/public/hdr_metadata_defs.h
@@ -54,7 +54,7 @@ enum hdr_per_frame_metadata_keys {
   KEY_MIN_LUMINANCE,
   KEY_MAX_CONTENT_LIGHT_LEVEL,
   KEY_MAX_FRAME_AVERAGE_LIGHT_LEVEL,
-  KEY_HDR10_PLUS_SEI
+  KEY_NUM_PER_FRAME_METADATA_KEYS
 };
 
 struct hdr_metadata_dynamic {

--- a/public/nativedisplay.h
+++ b/public/nativedisplay.h
@@ -100,6 +100,9 @@ class NativeDisplay {
                                   float *outMaxLuminance,
                                   float *outMaxAverageLuminance,
                                   float *outMinLuminance) = 0;
+
+  virtual bool GetPerFrameMetadataKeys(uint32_t *outNumKeys,
+                                       int32_t *outKeys) = 0;
   /**
    * API for getting connected display's pipe id.
    * @return "-1" for unconnected display, valid values are 0 ~ 2.

--- a/wsi/drm/drmdisplay.cpp
+++ b/wsi/drm/drmdisplay.cpp
@@ -707,6 +707,16 @@ bool DrmDisplay::GetHdrCapabilities(uint32_t *outNumTypes, int32_t *outTypes,
   return true;
 }
 
+bool DrmDisplay::GetPerFrameMetadataKeys(uint32_t *outNumKeys,
+                                         int32_t *outKeys) {
+  *outNumKeys = KEY_NUM_PER_FRAME_METADATA_KEYS;
+
+  for (int i = 0; i < KEY_NUM_PER_FRAME_METADATA_KEYS; i++) {
+    *(outKeys + i) = i;
+  }
+  return true;
+}
+
 void DrmDisplay::UpdateDisplayConfig() {
   // update the activeConfig
   SPIN_LOCK(display_lock_);

--- a/wsi/drm/drmdisplay.h
+++ b/wsi/drm/drmdisplay.h
@@ -148,6 +148,8 @@ class DrmDisplay : public PhysicalDisplay {
                           float *outMaxLuminance, float *outMaxAverageLuminance,
                           float *outMinLuminance) override;
 
+  bool GetPerFrameMetadataKeys(uint32_t *outNumKeys, int32_t *outKeys) override;
+
   bool GetDisplayIdentificationData(uint8_t *outPort, uint32_t *outDataSize,
                                     uint8_t *outData) override;
 

--- a/wsi/physicaldisplay.h
+++ b/wsi/physicaldisplay.h
@@ -133,6 +133,8 @@ class PhysicalDisplay : public NativeDisplay, public DisplayPlaneHandler {
                           float *outMaxLuminance, float *outMaxAverageLuminance,
                           float *outMinLuminance) = 0;
 
+  bool GetPerFrameMetadataKeys(uint32_t *outNumKeys, int32_t *outKeys) = 0;
+
   bool EnableDRMCommit(bool enable) override;
 
   /**


### PR DESCRIPTION
Change-Id: I5c64274ad5bf913f9811468e09945cfd2e9eb7e0
Tests: No
Tracked-On:
Signed-off-by: Wan Shuang <shuang.wan@intel.com>