### PR TITLE
[HDR & WCG patch1] Fix videolayer render issues

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -46,6 +46,7 @@ testlayers_SOURCES = \
     ./common/layerrenderer.cpp \
     ./common/gllayerrenderer.cpp \
     ./common/glcubelayerrenderer.cpp \
+	./common/videolayerrenderer.cpp \
     ./common/esTransform.cpp \
     ./common/jsonhandlers.cpp \
     ./apps/jsonlayerstest.cpp

--- a/tests/apps/jsonlayerstest.cpp
+++ b/tests/apps/jsonlayerstest.cpp
@@ -702,7 +702,6 @@ static void init_frames(int32_t width, int32_t height) {
           printf("un-recognized layer type!\n");
           exit(-1);
       }
-
       if (!renderer->Init(layer_parameter.source_width,
                           layer_parameter.source_height, gbm_format,
                           usage_format, usage, &gl,


### PR DESCRIPTION
In Linux env, the jsontestlayer expects videolayer renderer calls
which wasn't built.

Change-Id: Iab15dddcaf1214e7ec8ee40485a719328f98a17f
Tests: In Linux environment, testlayers works for bgra.
Tracked-On: None
Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>